### PR TITLE
fly.ioのマシンが最低1台は常時稼働しているように変更

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -17,7 +17,7 @@ console_command = '/rails/bin/rails console'
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ['app']
 
   [[http_service.checks]]


### PR DESCRIPTION
・一定時間アクセスがないとfly.ioのマシンが止まってしまい初回アクセスに時間がかかってしまうため。