### PR TITLE
カード詳細ページへのリンクをただのテキストに変更

### DIFF
--- a/app/views/cards/_card.html.erb
+++ b/app/views/cards/_card.html.erb
@@ -4,10 +4,10 @@
       <div class="a-card min-h-24 w-full flex justify-between border-2 border-solid border-[#aaaaaa] rounded-md mb-2">
         <div class="phrase-pair w-full h-auto grid justify-items-center divide-y-2 divide-[#b0b0b0] divide-dashed">
           <div class="ja-phrase grid content-center w-full h-auto text-xl">
-            <p><%= link_to card.ja_phrase, card_path(card), data: { turbo_frame: '_top' }, class: "flex justify-center mx-[5px]" %></p>
+            <p class="flex justify-center mx-[5px]"><%= card.ja_phrase %></p>
           </div>
           <div class="en-phrase grid content-center w-full h-auto text-xl">
-            <p><%= link_to card.en_phrase, card_path(card), data: { turbo_frame: '_top' }, class: "flex justify-center mx-[5px]" %></p>
+            <p  class="flex justify-center mx-[5px]"><%= card.en_phrase %></p>
           </div>
         </div>
       </div>

--- a/app/views/cards/review.html.erb
+++ b/app/views/cards/review.html.erb
@@ -14,10 +14,10 @@
         <div class="a-card h-24 h-full w-full flex justify-between border-2 border-solid border-[#aaaaaa] rounded-md mb-2">
           <div class="phrase-pair h-full w-full grid justify-items-center divide-y-2 divide-[#b0b0b0] divide-dashed">
             <div class="ja-phrase min-h-16 grid content-center w-full flex justify-center text-2xl">
-              <p>・<%= link_to @card.ja_phrase, card_path(@card), data: { turbo_frame: '_top' } %></p>
+              <p><%= @card.ja_phrase %></p>
             </div>
             <div data-review-target="enPhrase" class="en-phrase min-h-16 grid content-center w-full hidden flex justify-center text-2xl">
-              <p>・<%= link_to @card.en_phrase, card_path(@card), data: { turbo_frame: '_top' } %></p>
+              <p><%= @card.en_phrase %></p>
             </div>
           </div>
         </div>

--- a/spec/system/cards_spec.rb
+++ b/spec/system/cards_spec.rb
@@ -32,17 +32,6 @@ RSpec.describe "Cards", type: :system do
     expect(page).to have_content('testing a microphone', wait: 10)
   end
 
-  it 'display a details page of cards', :js do
-    visit cards_path
-    expect(page).to have_content 'フレーズ一覧'
-    click_on cards[0].ja_phrase
-    expect(page).to have_content '詳細'
-    expect(page).to have_content cards[0].ja_phrase
-    expect(page).to have_content cards[0].en_phrase
-    expect(page).not_to have_content cards[1].ja_phrase
-    expect(page).not_to have_content cards[1].en_phrase
-  end
-
   it 'deletes a card', :js do
     visit card_path(cards[0])
     expect(page).to have_content cards[0].ja_phrase


### PR DESCRIPTION
詳細ページへわざわざ遷移してまで単体のカードを閲覧する必要性が薄く、むしろカードのフレーズをコピーしようとしたときや復習モードで学習中に意図しない遷移が発生してしまいユーザー体験を損なうと判断したため、基本的に直接のリンクは設置しないこととした。
ただし、カード一覧の画面上で編集キャンセルを行なった場合に呼び出されるのは詳細画面(cards#show)なので、ルーティングやビューそのものは残しておく必要がある。