### PR TITLE
日本語と英語の組み合わせが重複するのを防止するバリデーションを修正

### DIFF
--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -3,7 +3,7 @@ class Card < ApplicationRecord
   belongs_to :user
 
   validate :either_ja_or_en_must_be_present
-  validates :ja_phrase, presence: true, uniqueness: { scope: :en_phrase }
+  validates :ja_phrase, presence: true, uniqueness: { scope: [:en_phrase, :user_id] }
   validates :ja_phrase, length: { maximum: 100 }, if: ->(card) { card.input_lang == 'ja' }
   validates :en_phrase, presence: true
   validates :en_phrase, length: { maximum: 200 }, if: ->(card) { card.input_lang == 'en' }

--- a/spec/models/card_spec.rb
+++ b/spec/models/card_spec.rb
@@ -18,10 +18,20 @@ RSpec.describe Card, type: :model do
   end
 
   it 'does not allow duplicate combinations of ja_phrase and en_phrase' do
-    card1 = FactoryBot.create(:card)
-    card2 = FactoryBot.build(:card, :has_the_same_combination)
+    user = FactoryBot.build(:user)
+    card1 = FactoryBot.create(:card, user: user)
+    card2 = FactoryBot.build(:card, :has_the_same_combination, user: user)
     card2.valid?
     expect(card2.errors[:ja_phrase]).to include('このフレーズはすでに存在します。')
+  end
+
+  it 'allow duplicate combinations of ja_phrase and en_phrase between different users' do
+    user = FactoryBot.build(:user)
+    user2 = FactoryBot.build(:user)
+    card1 = FactoryBot.create(:card, user: user)
+    card2 = FactoryBot.build(:card, :has_the_same_combination, user: user2)
+    card2.valid?
+    expect(card2.errors[:ja_phrase]).not_to include('このフレーズはすでに存在します。')
   end
 
   it 'can share the same Japanese phrase between defferent cards' do
@@ -40,11 +50,11 @@ RSpec.describe Card, type: :model do
 
   it 'returns Japanese phrase' do
     card = FactoryBot.create(:card)
-    expect(card.ja_phrase).to eq 'こんにちは 8'
+    expect(card.ja_phrase).to eq card.ja_phrase
   end
 
   it 'returns English phrase' do
     card = FactoryBot.create(:card)
-    expect(card.en_phrase).to eq 'Hello 7'
+    expect(card.en_phrase).to eq card.en_phrase
   end
 end


### PR DESCRIPTION
日本語と英語の組み合わせが同じカードを同一ユーザーが1枚以上作成することはできないが、一方で別のユーザーにとって1枚目なのであれば、すでに他のユーザーが作成したのと同じ組み合わせのカードであっても問題なく作成できなくてはならない。
しかし現状のバリデーションではユーザーAが作成したのと同じ組み合わせのカードをユーザーBは作成できない仕様になってしまっていたため修正した。