### PR TITLE
フィルターで選択したスコープを維持したまま検索ができるように修正した

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -4,7 +4,7 @@ class CardsController < ApplicationController
   before_action :authorize_user, only: [:show, :edit, :update, :destroy]
 
   def index
-    @target = params[:target]
+    @target = params[:target] || 'all'
     @target = 'all' unless target_allowlist.include?(@target)
 
     @cards =

--- a/app/javascript/controllers/card_filter_controller.js
+++ b/app/javascript/controllers/card_filter_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from "@hotwired/stimulus";
 
-// Connects to data-controller="card-filter"
+// connects to data-controller="card-filter"
 export default class extends Controller {
   static targets = ["filterButton"];
 
@@ -11,6 +11,17 @@ export default class extends Controller {
         (target) => target !== event.currentTarget
       );
       unclickedButtons.map((button) => button.classList.remove("is-selected"));
+    }
+
+    const turboParamsString =
+      event.currentTarget.querySelector("a").dataset.turboParams;
+    const turboParams = JSON.parse(turboParamsString);
+
+    const newTarget = turboParams.target;
+
+    const hiddenField = document.querySelector('input[name="target"]');
+    if (hiddenField) {
+      hiddenField.setAttribute("value", newTarget);
     }
   }
 }

--- a/app/views/cards/index.html.erb
+++ b/app/views/cards/index.html.erb
@@ -6,15 +6,15 @@
   <nav class="w-3/5 my-4">
     <ul data-controller="card-filter" class="filters flex justify-start">
       <li class="a-filter is-selected flex items-center justify-center w-[35%] mr-2 h-8 rounded-full border border-[#b0b0b0] text-[#b0b0b0] hover:bg-[#87faf9]" id="filter-all" data-card-filter-target="filterButton" data-action="click->card-filter#changeFilterDesign">
-        <%= link_to '全て', cards_path, data: {turbo_frame: "cards"}, class: 'flex justify-center items-center w-full h-full'%>
+        <%= link_to '全て', cards_path, class: 'flex justify-center items-center w-full h-full', data: { turbo_frame: "cards", turbo_params: { target: 'all' } } %>
       </li>
       <li class="a-filter flex items-center justify-center w-[35%] mr-2 h-8 rounded-full border border-[#b0b0b0] text-[#b0b0b0] text-[10px] md:text-base hover:bg-[#87faf9]" id="filter-memorized" data-card-filter-target="filterButton" data-action="click->card-filter#changeFilterDesign">
-        <%= link_to cards_path(target: 'memorized'), data: {turbo_frame: "cards"}, class: 'flex justify-center items-center w-full h-full' do %>
+        <%= link_to cards_path(target: 'memorized'), class: 'flex justify-center items-center w-full h-full', data: { turbo_frame: "cards", turbo_params: { target: 'memorized' } } do %>
           <i class="fa-solid fa-check fa-fw" style="color: #ffb74d;"></i>覚えた！
         <% end %>
       </li>
       <li class="a-filter flex items-center justify-center w-[35%] h-8 rounded-full border border-[#b0b0b0] text-[#b0b0b0] text-[8px] md:text-base hover:bg-[#87faf9]" id="filter-unmemorized" data-card-filter-target="filterButton" data-action="click->card-filter#changeFilterDesign">
-        <%= link_to cards_path(target: 'unmemorized'), data: {turbo_frame: "cards"}, class: 'flex justify-center items-center w-full h-full' do %>
+        <%= link_to cards_path(target: 'unmemorized'), class: 'flex justify-center items-center w-full h-full', data: { turbo_frame: "cards", turbo_params: { target: 'unmemorized' } } do %>
            <i class="fa-solid fa-check fa-fw"></i>覚えていない
          <% end %>
       </li>


### PR DESCRIPTION
・フィルターを選択するとturbo_frame_tag"cards"の内部のみが更新されるが、検索フォームはその外にあるため、検索フォーム内のhidden_field_tagに渡しているtargetが更新されず（フィルターの現在の状態が反映されず）、常にスコープが`all`の状態で検索がかかってしまい、絞り込みと検索の併用ができていなかったため修正した。