### PR TITLE
Dockerfileのassets precompile時に実行するコードを変更

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ COPY . .
 RUN bundle exec bootsnap precompile app/ lib/
 
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
-RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
+RUN SECRET_KEY_BASE_DUMMY=1 DEEPL_API_KEY=dummy ./bin/rails assets:precompile
 
 
 


### PR DESCRIPTION
デプロイのassets precompile時にDeepLのAPIキーが見当たらないエラーが出るためダミーキーを渡すよう変更した