### PR TITLE
復習モードの使い方の文字に対する装飾の仕方を変更した

### DIFF
--- a/app/views/cards/reviews/_usage.html.erb
+++ b/app/views/cards/reviews/_usage.html.erb
@@ -1,5 +1,5 @@
 <div class="mt-8">
-  <h2 class="text-base md:text-xl">＜復習モードの使い方＞</h2>
+  <h2 class="text-base md:text-xl font-semibold underline">復習モードの使い方</h2>
   <div class="text-sm md:text-lg mb-8 p-4">
     <ol class="list-decimal">
       <li>日本語だけを見て英語のフレーズを思い出しましょう。（声に出して音読すると効果的です。）</li>


### PR DESCRIPTION
テキストで装飾文字を使用して装飾してしまっていたためCSSによる装飾に変更した。

## 関連issue
- #171 