### PR TITLE
システムスペックを修正

### DIFF
--- a/spec/factories/cards.rb
+++ b/spec/factories/cards.rb
@@ -40,12 +40,5 @@ FactoryBot.define do
       en_phrase { 'Incremental search is available on the card list screen.' }
       memorized_at { nil }
     end
-
-    trait :belonging_to_another_user do
-      ja_phrase { '他のユーザーが作成したカードです' }
-      en_phrase { 'Cards created by other users.' }
-      memorized_at { nil }
-      association :user, factory: [:user, :another_user]
-    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,17 +1,9 @@
 FactoryBot.define do
   factory :user do
-    name { "User1" }
-    email { "user1@example.com" }
+    sequence(:name) { |n| "User#{n}" }
+    sequence(:email) { |n| "user#{n}@example.com" }
     provider { "google_oauth2" }
     uid { SecureRandom.uuid }
     image { "/app/assets/images/default_user_icon" }
-
-    trait :another_user do
-      name { "User2" }
-      email { "user2@example.com" }
-      provider { "google_oauth2" }
-      uid { SecureRandom.uuid }
-      image { "/app/assets/images/default_user_icon" }
-    end
   end
 end

--- a/spec/helpers/sessions_helper_spec.rb
+++ b/spec/helpers/sessions_helper_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe SessionsHelper, type: :helper do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { create(:user) }
   describe '#current_user' do
     it 'returns a user when the user has logged in' do
       log_in(user)

--- a/spec/models/card_spec.rb
+++ b/spec/models/card_spec.rb
@@ -2,17 +2,17 @@ require 'rails_helper'
 
 RSpec.describe Card, type: :model do
   it 'can have cards with the same content between different users' do
-    user1 = FactoryBot.build(:user)
-    user2 = FactoryBot.build(:user)
-    card1 = FactoryBot.create(:card, user: user1)
-    card2 = FactoryBot.build(:card, :has_the_same_combination, user: user2)
+    user1 = build(:user)
+    user2 = build(:user)
+    card1 = create(:card, user: user1)
+    card2 = build(:card, :has_the_same_combination, user: user2)
     card2.valid?
     expect(card2.errors[:ja_phrase]).not_to include('このフレーズはすでに存在します。')
   end
 
   it 'must have Japanese or English phrase when a user submits a creation form' do
-    user = FactoryBot.build(:user)
-    card = FactoryBot.build(:card, :without_any_phrases, user: user)
+    user = build(:user)
+    card = build(:card, :without_any_phrases, user: user)
     card.valid?
     expect(card.errors[:base]).to include('フレーズを入力してください。')
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { create(:user) }
 
   describe '.find_or_new_auth_hash' do
     it 'returns the stored user if the user already exists' do

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,5 +1,5 @@
 RSpec.configure do |config|
   config.before(:each, type: :system) do
-    driven_by :selenium_chrome_headless
+    driven_by :selenium_chrome
   end
 end

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,5 +1,5 @@
 RSpec.configure do |config|
   config.before(:each, type: :system) do
-    driven_by :selenium_chrome
+    driven_by :selenium_chrome_headless
   end
 end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/system/cards_spec.rb
+++ b/spec/system/cards_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe "Cards", type: :system do
   let(:user) { create(:user) }
   let(:another_user) { create(:user) }
-  let!(:cards) { create_list(:card, 3, user: user) }
+  let!(:cards) { create_list(:card, 3, user:) }
   let(:card_belonging_to_another_user) { create(:card, user: another_user) }
 
   before do
@@ -105,8 +105,8 @@ RSpec.describe "Cards", type: :system do
   end
 
   scenario 'a user reviews unmemorized cards in review mode' do
-    unmemorized_card1 = create(:card, :unmemorized1, user: user)
-    unmemorized_card2 = create(:card, :unmemorized2, user: user)
+    unmemorized_card1 = create(:card, :unmemorized1, user:)
+    unmemorized_card2 = create(:card, :unmemorized2, user:)
 
     visit review_cards_path
     expect(page).to have_content '復習モード'
@@ -127,54 +127,48 @@ RSpec.describe "Cards", type: :system do
   end
 
   scenario 'a user removes a card from review mode by clicking a check button' do
-    Capybara.using_session("another_session_in_cards_spec") do
-      Capybara.current_session.driver.browser.manage.window.resize_to(1280, 800)
-      log_in_as user
-      expect(page).to have_content 'フレーズ一覧'
-      unmemorized_card1 = create(:card, :unmemorized1, user: user)
-      unmemorized_card2 = create(:card, :unmemorized2, user: user)
-      visit cards_path
-      expect(page).to have_content unmemorized_card2.ja_phrase
-      expect(page).to have_content unmemorized_card2.en_phrase
-      within "#card-#{unmemorized_card2.id}" do
-        find('#memorized-button').click
-      end
-      expect(page).to have_selector('.checked', wait: 5)
-      find_by_id('menu-close').click
-      expect(page).to have_no_css('#menu-open.hidden', wait: 5)
-      within('#menu-open') do
-        click_on '復習モード'
-      end
-      expect(page).to have_content '復習モード'
-      expect(page).not_to have_content unmemorized_card2.ja_phrase
-      expect(page).not_to have_content '次のフレーズへ'
+    Capybara.current_session.driver.browser.manage.window.resize_to(1280, 800)
+    expect(page).to have_content 'フレーズ一覧'
+    unmemorized_card1 = create(:card, :unmemorized1, user:)
+    unmemorized_card2 = create(:card, :unmemorized2, user:)
+    visit cards_path
+    expect(page).to have_content unmemorized_card2.ja_phrase
+    expect(page).to have_content unmemorized_card2.en_phrase
+    within "#card-#{unmemorized_card2.id}" do
+      find('#memorized-button').click
     end
+    expect(page).to have_selector('.checked', wait: 5)
+    find_by_id('menu-close').click
+    expect(page).to have_no_css('#menu-open.hidden', wait: 5)
+    within('#menu-open') do
+      click_on '復習モード'
+    end
+    expect(page).to have_content '復習モード'
+    expect(page).not_to have_content unmemorized_card2.ja_phrase
+    expect(page).not_to have_content '次のフレーズへ'
   end
 
   scenario 'a user add a card to review mode by clicking a check button' do
-    Capybara.using_session("another_session_in_cards_spec") do
-      Capybara.current_session.driver.browser.manage.window.resize_to(1280, 800)
-      log_in_as user
-      card = create(:card, user: user)
-      visit cards_path
-      expect(page).to have_content card.ja_phrase
-      expect(page).to have_content card.en_phrase
-      within "#card-#{card.id}" do
-        find('#memorized-button').click
-      end
-      expect(page).to have_selector('.unchecked', wait: 5)
-      find_by_id('menu-close').click
-      expect(page).to have_no_css('#menu-open.hidden', wait: 5)
-      within('#menu-open') do
-        click_on '復習モード'
-      end
-      expect(page).to have_content '復習モード'
-      expect(page).to have_content card.ja_phrase
+    Capybara.current_session.driver.browser.manage.window.resize_to(1280, 800)
+    card = create(:card, user:)
+    visit cards_path
+    expect(page).to have_content card.ja_phrase
+    expect(page).to have_content card.en_phrase
+    within "#card-#{card.id}" do
+      find('#memorized-button').click
     end
+    expect(page).to have_selector('.unchecked', wait: 5)
+    find_by_id('menu-close').click
+    expect(page).to have_no_css('#menu-open.hidden', wait: 5)
+    within('#menu-open') do
+      click_on '復習モード'
+    end
+    expect(page).to have_content '復習モード'
+    expect(page).to have_content card.ja_phrase
   end
 
   scenario 'a user search for cards using incremental search' do
-    card = create(:card, :for_incremental_search_test, user: user)
+    card = create(:card, :for_incremental_search_test, user:)
     visit cards_path
     fill_in 'フレーズを検索', with: 'インクリメンタル'
     expect(page).to have_content 'カード一覧画面ではインクリメンタルサーチが使用できます。'
@@ -186,8 +180,8 @@ RSpec.describe "Cards", type: :system do
   end
 
   scenario 'a user filter the card list' do
-    memorized_card = create(:card, user: user)
-    unmemorized_card = create(:card, :unmemorized1, user: user)
+    memorized_card = create(:card, user:)
+    unmemorized_card = create(:card, :unmemorized1, user:)
     visit cards_path
     within '.filters' do
       click_on '覚えた'

--- a/spec/system/cards_spec.rb
+++ b/spec/system/cards_spec.rb
@@ -1,17 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe "Cards", type: :system do
-  let(:user) { FactoryBot.create(:user) }
-  let!(:cards) { FactoryBot.create_list(:card, 3, user: user) }
-  let(:card_belonging_to_another_user) { FactoryBot.create(:card, :belonging_to_another_user) }
+  let(:user) { create(:user) }
+  let(:another_user) { create(:user) }
+  let!(:cards) { create_list(:card, 3, user: user) }
+  let(:card_belonging_to_another_user) { create(:card, user: another_user) }
 
   before do
     log_in_as user
-    expect(page).to have_content('ログインしました', wait: 10)
-    expect(page).to have_content('フレーズ一覧', wait: 10)
+    expect(page).to have_content('ログインしました', wait: 5)
+    expect(page).to have_content('フレーズ一覧', wait: 5)
   end
 
-  scenario 'a user visits the card list', :js do
+  scenario 'a user visits the card list' do
     expect(page).to have_content 'フレーズ一覧'
     expect(page).to have_content cards[0].ja_phrase
     expect(page).to have_content cards[0].en_phrase
@@ -21,40 +22,40 @@ RSpec.describe "Cards", type: :system do
     expect(page).to have_content cards[2].en_phrase
   end
 
-  scenario 'a user creates a new card with Japanese', :js do
+  scenario 'a user creates a new card with Japanese' do
     visit cards_path
     expect(page).to have_content 'フレーズ一覧'
     find('.creation_icon').click
     fill_in '翻訳したいフレーズ', with: '本日は晴天なり'
     click_on '翻訳する'
-    expect(page).to have_content('カードを作成しました', wait: 10)
-    expect(page).to have_content('フレーズ一覧', wait: 10)
-    expect(page).to have_content('本日は晴天なり', wait: 10)
-    expect(page).to have_content('testing a microphone', wait: 10)
+    expect(page).to have_content('カードを作成しました', wait: 5)
+    expect(page).to have_content('フレーズ一覧', wait: 5)
+    expect(page).to have_content('本日は晴天なり', wait: 5)
+    expect(page).to have_content('testing a microphone', wait: 5)
   end
 
-  scenario 'a user creates a new card with English', :js do
+  scenario 'a user creates a new card with English' do
     visit cards_path
     expect(page).to have_content 'フレーズ一覧'
     find('.creation_icon').click
     fill_in '翻訳したいフレーズ', with: 'Failure teaches success.'
     click_on '翻訳する'
-    expect(page).to have_content('カードを作成しました', wait: 10)
-    expect(page).to have_content('フレーズ一覧', wait: 10)
-    expect(page).to have_content('失敗は成功を教えてくれる。', wait: 10)
-    expect(page).to have_content('Failure teaches success.', wait: 10)
+    expect(page).to have_content('カードを作成しました', wait: 5)
+    expect(page).to have_content('フレーズ一覧', wait: 5)
+    expect(page).to have_content('失敗は成功を教えてくれる。', wait: 5)
+    expect(page).to have_content('Failure teaches success.', wait: 5)
   end
 
-  scenario 'a user fails to create a new card', :js do
+  scenario 'a user fails to create a new card' do
     visit cards_path
     expect(page).to have_content 'フレーズ一覧'
     find('.creation_icon').click
     fill_in '翻訳したいフレーズ', with: ''
     click_on '翻訳する'
-    expect(page).to have_content('フレーズを入力してください。', wait: 10)
+    expect(page).to have_content('フレーズを入力してください。', wait: 5)
   end
 
-  scenario 'a user deletes a card from show page', :js do
+  scenario 'a user deletes a card from show page' do
     visit card_path(cards[0])
     expect(page).to have_content cards[0].ja_phrase
     expect(page).to have_content cards[0].en_phrase
@@ -63,12 +64,12 @@ RSpec.describe "Cards", type: :system do
     accept_confirm "本当に削除しますか？" do
       click_on '削除する'
     end
-    expect(page).to have_content('フレーズ一覧', wait: 10)
+    expect(page).to have_content('フレーズ一覧', wait: 5)
     expect(page).not_to have_content cards[0].ja_phrase
     expect(page).not_to have_content cards[0].en_phrase
   end
 
-  scenario 'a user deletes a card from card list', :js do
+  scenario 'a user deletes a card from card list' do
     expect(page).to have_content 'フレーズ一覧'
     within "#card-#{cards[0].id}" do
       click_on '編集する'
@@ -76,12 +77,12 @@ RSpec.describe "Cards", type: :system do
     accept_confirm "本当に削除しますか？" do
       click_on '削除する'
     end
-    expect(page).to have_content('フレーズ一覧', wait: 10)
+    expect(page).to have_content('フレーズ一覧', wait: 5)
     expect(page).not_to have_content cards[0].ja_phrase
     expect(page).not_to have_content cards[0].en_phrase
   end
 
-  scenario 'a user updates a card', :js do
+  scenario 'a user updates a card' do
     visit cards_path
     expect(page).to have_content "フレーズ一覧"
     click_on '編集する', match: :first
@@ -93,19 +94,19 @@ RSpec.describe "Cards", type: :system do
     expect(page).to have_content 'Updated card'
   end
 
-  scenario 'a user fails to update a card', :js do
+  scenario 'a user fails to update a card' do
     visit cards_path
     expect(page).to have_content "フレーズ一覧"
     click_on '編集する', match: :first
     fill_in 'card[ja_phrase]', with: ''
     fill_in 'card[en_phrase]', with: ''
     click_on '更新する'
-    expect(page).to have_content('フレーズを入力してください。', wait: 15)
+    expect(page).to have_content('フレーズを入力してください。', wait: 5)
   end
 
-  scenario 'a user reviews unmemorized cards in review mode', :js do
-    unmemorized_card1 = FactoryBot.create(:card, :unmemorized1, user: user)
-    unmemorized_card2 = FactoryBot.create(:card, :unmemorized2, user: user)
+  scenario 'a user reviews unmemorized cards in review mode' do
+    unmemorized_card1 = create(:card, :unmemorized1, user: user)
+    unmemorized_card2 = create(:card, :unmemorized2, user: user)
 
     visit review_cards_path
     expect(page).to have_content '復習モード'
@@ -125,22 +126,22 @@ RSpec.describe "Cards", type: :system do
     expect(page).not_to have_content 'Almost there. But I haven\'t memorized it yet.'
   end
 
-  scenario 'a user removes a card from review mode by clicking a check button', :js do
+  scenario 'a user removes a card from review mode by clicking a check button' do
     Capybara.using_session("another_session_in_cards_spec") do
       Capybara.current_session.driver.browser.manage.window.resize_to(1280, 800)
       log_in_as user
       expect(page).to have_content 'フレーズ一覧'
-      unmemorized_card1 = FactoryBot.create(:card, :unmemorized1, user: user)
-      unmemorized_card2 = FactoryBot.create(:card, :unmemorized2, user: user)
+      unmemorized_card1 = create(:card, :unmemorized1, user: user)
+      unmemorized_card2 = create(:card, :unmemorized2, user: user)
       visit cards_path
       expect(page).to have_content unmemorized_card2.ja_phrase
       expect(page).to have_content unmemorized_card2.en_phrase
       within "#card-#{unmemorized_card2.id}" do
         find('#memorized-button').click
       end
-      expect(page).to have_selector('.checked', wait: 10)
+      expect(page).to have_selector('.checked', wait: 5)
       find_by_id('menu-close').click
-      expect(page).to have_no_css('#menu-open.hidden', wait: 20)
+      expect(page).to have_no_css('#menu-open.hidden', wait: 5)
       within('#menu-open') do
         click_on '復習モード'
       end
@@ -150,20 +151,20 @@ RSpec.describe "Cards", type: :system do
     end
   end
 
-  scenario 'a user add a card to review mode by clicking a check button', :js do
+  scenario 'a user add a card to review mode by clicking a check button' do
     Capybara.using_session("another_session_in_cards_spec") do
       Capybara.current_session.driver.browser.manage.window.resize_to(1280, 800)
       log_in_as user
-      card = FactoryBot.create(:card, user: user)
+      card = create(:card, user: user)
       visit cards_path
       expect(page).to have_content card.ja_phrase
       expect(page).to have_content card.en_phrase
       within "#card-#{card.id}" do
         find('#memorized-button').click
       end
-      expect(page).to have_selector('.unchecked', wait: 10)
+      expect(page).to have_selector('.unchecked', wait: 5)
       find_by_id('menu-close').click
-      expect(page).to have_no_css('#menu-open.hidden', wait: 20)
+      expect(page).to have_no_css('#menu-open.hidden', wait: 5)
       within('#menu-open') do
         click_on '復習モード'
       end
@@ -172,8 +173,8 @@ RSpec.describe "Cards", type: :system do
     end
   end
 
-  scenario 'a user search for cards using incremental search', :js do
-    card = FactoryBot.create(:card, :for_incremental_search_test, user: user)
+  scenario 'a user search for cards using incremental search' do
+    card = create(:card, :for_incremental_search_test, user: user)
     visit cards_path
     fill_in 'フレーズを検索', with: 'インクリメンタル'
     expect(page).to have_content 'カード一覧画面ではインクリメンタルサーチが使用できます。'
@@ -184,9 +185,9 @@ RSpec.describe "Cards", type: :system do
     expect(page).to have_selector('.a-card', count: 1)
   end
 
-  scenario 'a user filter the card list', :js do
-    memorized_card = FactoryBot.create(:card, user: user)
-    unmemorized_card = FactoryBot.create(:card, :unmemorized1, user: user)
+  scenario 'a user filter the card list' do
+    memorized_card = create(:card, user: user)
+    unmemorized_card = create(:card, :unmemorized1, user: user)
     visit cards_path
     within '.filters' do
       click_on '覚えた'
@@ -198,23 +199,23 @@ RSpec.describe "Cards", type: :system do
     expect(page).to have_content unmemorized_card.ja_phrase
   end
 
-  scenario 'the spinner show up while card creation', :js do
+  scenario 'the spinner show up while card creation' do
     visit cards_path
     find('.creation_icon').click
     fill_in '翻訳したいフレーズ', with: '本日は晴天なり'
     click_on '翻訳する'
-    expect(page).to have_content('Now translating...', wait: 10)
-    expect(page).to have_selector('.spinner', wait: 10)
-    expect(page).to have_content('本日は晴天なり', wait: 10)
-    expect(page).to have_content('testing a microphone', wait: 10)
+    expect(page).to have_content('Now translating...', wait: 5)
+    expect(page).to have_selector('.spinner', wait: 5)
+    expect(page).to have_content('本日は晴天なり', wait: 5)
+    expect(page).to have_content('testing a microphone', wait: 5)
   end
 
-  scenario 'a user can\'t access the cards belonging to other users', :js do
+  scenario 'a user can\'t access the cards belonging to other users' do
     visit card_path(card_belonging_to_another_user)
     expect(page).to have_content('ActiveRecord::RecordNotFound in CardsController#show')
   end
 
-  scenario 'user cannot access to card list before login', :js do
+  scenario 'user cannot access to card list before login' do
     log_out
     visit cards_path
     expect(page).to have_content('ログインしてください')

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "Cards", type: :system do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { create(:user) }
 
   describe 'not logged in' do
     it 'visit terms page', :js do

--- a/spec/system/home_spec.rb
+++ b/spec/system/home_spec.rb
@@ -25,14 +25,14 @@ RSpec.describe "Cards", type: :system do
 
     it 'visit terms page', :js do
       find_by_id('menu-close').click
-      expect(page).to have_no_css('#menu-open.hidden', wait: 20)
+      expect(page).to have_no_css('#menu-open.hidden', wait: 5)
       click_on '利用規約', match: :first
       expect(page).to have_css 'h1', text: '利用規約'
     end
 
     it 'visit privacy policy page', :js do
       find_by_id('menu-close').click
-      expect(page).to have_no_css('#menu-open.hidden', wait: 20)
+      expect(page).to have_no_css('#menu-open.hidden', wait: 5)
       click_on 'プライバシーポリシー', match: :first
       expect(page).to have_css 'h1', text: 'プライバシーポリシー'
     end

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "Sessions", type: :system do
-  let(:user) { FactoryBot.create(:user) }
+  let(:user) { create(:user) }
 
   it 'user log in', :js do
     log_in_as user

--- a/spec/system/sessions_spec.rb
+++ b/spec/system/sessions_spec.rb
@@ -25,16 +25,14 @@ RSpec.describe "Sessions", type: :system do
   end
 
   it 'user log out', :js do
-    Capybara.using_session("another_session_in_sessions_spec") do
-      log_in_as user
-      expect(page).to have_content 'ログインしました'
-      find_by_id('menu-close').click
-      within "#menu-open" do
-        click_on 'ログアウト'
-      end
-      expect(page).to have_content '翻訳と記録を同時にしてくれる'
-      expect(page).to have_content '英語フレーズ帳'
-      expect(page).to have_content 'ログアウトしました'
+    log_in_as user
+    expect(page).to have_content 'ログインしました'
+    find_by_id('menu-close').click
+    within "#menu-open" do
+      click_on 'ログアウト'
     end
+    expect(page).to have_content '翻訳と記録を同時にしてくれる'
+    expect(page).to have_content '英語フレーズ帳'
+    expect(page).to have_content 'ログアウトしました'
   end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,19 +1,23 @@
 require 'rails_helper'
 
 RSpec.describe "Users", type: :system do
-  let(:user) { FactoryBot.create(:user) }
-
-  it 'a user withdrawals', :js do
+  it 'a user withdrawals' do
     Capybara.using_session("another_session_in_users_spec") do
+      user = FactoryBot.create(:user)
+      user_count = User.count
+
       log_in_as user
       find_by_id('menu-close').click
       expect(page).to have_content '退会'
       accept_confirm '退会すると今まで作成したカードは全て削除されます。退会してよろしいですか？' do
         click_on '退会'
       end
+
       expect(page).to have_content '翻訳と記録を同時にしてくれる'
       expect(page).to have_content '英語フレーズ帳'
       expect(page).to have_content '退会しました'
+
+      expect(User.count).to eq(user_count - 1)
     end
   end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -2,22 +2,19 @@ require 'rails_helper'
 
 RSpec.describe "Users", type: :system do
   it 'a user withdrawals' do
-    Capybara.using_session("another_session_in_users_spec") do
-      user = create(:user)
-      user_count = User.count
+    user = create(:user)
 
-      log_in_as user
-      find_by_id('menu-close').click
-      expect(page).to have_content '退会'
+    log_in_as user
+    find_by_id('menu-close').click
+    expect(page).to have_content '退会'
+    expect {
       accept_confirm '退会すると今まで作成したカードは全て削除されます。退会してよろしいですか？' do
         click_on '退会'
       end
-
-      expect(page).to have_content '翻訳と記録を同時にしてくれる'
-      expect(page).to have_content '英語フレーズ帳'
       expect(page).to have_content '退会しました'
+    }.to change { User.count }.by(-1)
 
-      expect(User.count).to eq(user_count - 1)
-    end
+    expect(page).to have_content '翻訳と記録を同時にしてくれる'
+    expect(page).to have_content '英語フレーズ帳'
   end
 end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe "Users", type: :system do
   it 'a user withdrawals' do
     Capybara.using_session("another_session_in_users_spec") do
-      user = FactoryBot.create(:user)
+      user = create(:user)
       user_count = User.count
 
       log_in_as user


### PR DESCRIPTION
- `spec/support/capybara.rb`内で`driven_by :selenium_chrome_headless`を設定しており、各スペックに個別で`:js`を記載する必要がなく、冗長になってしまうため削除した。
- `config.include FactoryBot::Syntax::Methods`を設定することで`FactoryBot.create`などのメソッド呼び出しの際にクラス名を省略して`create`などと記載できるようにした。
- UserのベースのFactoryで`name`と`email`の値が固定になっていたが、普通はユーザーごとに違うものが入るため`sequence`を使用するように変更した。それに合わせて`another_user`の`trait`は廃止した。
- `have_content`等のメソッドで`wait`を使用する際、全体的に待ち時間が長すぎたため短くした。
- `users_spec.rb`で退会処理の後にユーザー数が減っていることを確認する部分を追加した。