### PR TITLE
新規作成フォームと復習モード内のUI切り替えにかかるStimulusコントローラーの処理を見直した

### DIFF
--- a/app/javascript/controllers/creation_form_controller.js
+++ b/app/javascript/controllers/creation_form_controller.js
@@ -5,10 +5,6 @@ export default class extends Controller {
   static targets = ["creationForm"];
 
   changeVisibility() {
-    if (this.creationFormTarget.classList.contains("hidden")) {
-      this.creationFormTarget.classList.remove("hidden");
-    } else {
-      this.creationFormTarget.classList.add("hidden");
-    }
+    this.creationFormTarget.classList.toggle("hidden");
   }
 }

--- a/app/javascript/controllers/review_controller.js
+++ b/app/javascript/controllers/review_controller.js
@@ -6,13 +6,10 @@ export default class extends Controller {
   switchEnPhraseVisibility() {
     if (this.enPhraseTarget.classList.contains("hidden")) {
       this.enPhraseTarget.classList.remove("hidden");
+      this.switchingButtonTarget.textContent = "英文を隠す";
     } else {
       this.enPhraseTarget.classList.add("hidden");
+      this.switchingButtonTarget.textContent = "英文を表示";
     }
-
-    this.switchingButtonTarget.textContent =
-      this.switchingButtonTarget.textContent === "英文を表示"
-        ? "英文を隠す"
-        : "英文を表示";
   }
 }


### PR DESCRIPTION
- 新規作成フォームの表示/非表示を切り替える処理が冗長だったため修正した。
- 同様に、復習モード内の英文の表示を切り替える処理における冗長な部分を修正した。