### PR TITLE
usersテーブルにインデックスを追加した・emailカラムにNOT NULL制約を追加した

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
 
   validates :name, presence: true
   validates :provider, presence: true
-  validates :uid, presence: true
+  validates :uid, presence: true, uniqueness: { scope: :provider }
 
   class << self
     def find_or_new_from_auth_hash(auth_hash)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@ class User < ApplicationRecord
   validates :name, presence: true
   validates :provider, presence: true
   validates :uid, presence: true, uniqueness: { scope: :provider }
+  validates :email, presence: true
 
   class << self
     def find_or_new_from_auth_hash(auth_hash)

--- a/db/migrate/20250323070316_add_index_to_users.rb
+++ b/db/migrate/20250323070316_add_index_to_users.rb
@@ -1,0 +1,5 @@
+class AddIndexToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_index :users, %i[uid provider], unique: true
+  end
+end

--- a/db/migrate/20250323073430_add_not_null_constraint_to_email_to_users.rb
+++ b/db/migrate/20250323073430_add_not_null_constraint_to_email_to_users.rb
@@ -1,0 +1,5 @@
+class AddNotNullConstraintToEmailToUsers < ActiveRecord::Migration[7.2]
+  def change
+    change_column_null :users, :email, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_03_23_070316) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_23_073430) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -30,7 +30,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_03_23_070316) do
     t.string "uid", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "email"
+    t.string "email", null: false
     t.string "image"
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_19_101121) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_23_070316) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -32,6 +32,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_19_101121) do
     t.datetime "updated_at", null: false
     t.string "email"
     t.string "image"
+    t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
   add_foreign_key "cards", "users"


### PR DESCRIPTION
- ユーザーログイン時には`uid`と`provider`によってユーザーの検索を行うことから、この二つのカラムに対してインデックスを設定することとした。
- Googleアカウントを作成するためには何らかのメールアドレス（Gmail以外も含む）が必要であることから、メールアドレスを持たないGoogleアカウントは通常存在しないため、`email`カラムにNOT NULL制約を追加した。