### PR TITLE
reviews_controllerに早期リターンを追加・allow_browserのコメントアウトを解除

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,7 +3,7 @@ class ApplicationController < ActionController::Base
   before_action :authenticate
 
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
-  # allow_browser versions: :modern
+  allow_browser versions: :modern
 
   private
 

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,6 +1,9 @@
 class ReviewsController < ApplicationController
   def show
     cards = current_user.cards.unmemorized.order(created_at: :desc)
+
+    return @card = nil unless cards.present?
+
     if params[:id] == 'first'
       @card = cards.first
       @next_card = cards.where('id < ?', @card.id).first


### PR DESCRIPTION
・フレーズが一つも登録されていない状態で復習モードに遷移するとエラーになるため修正した。
・開発者ツールでの確認用にコメントアウトしていたallow_browserを有効化した。